### PR TITLE
Install dos2unix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
         clang \
         cmake \
         curl \
+        dos2unix \
         git \
         golang \
         libc++-dev \


### PR DESCRIPTION
Required for FFIG tests on a Windows hosted docker image.