### PR TITLE
Fix the pip3 install also

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN mkdir warmup \
 # Python dependencies
 RUN pip2 install --upgrade pip==9.0.3 && \
     pip2 install jinja2 nose pycodestyle virtualenv && \
-    pip3 install --upgrade pip && \
+    pip3 install --upgrade pip==9.0.3 && \
     pip3 install jinja2 nose pycodestyle virtualenv 
 
 # Ruby dependencies


### PR DESCRIPTION
Fixes #25 
With this merged, the ffig-base image (if rebuilt from this Dockerfile) contains the following rust tool versions:

```
+ rustup --version
rustup 1.14.0 (1e51b07cc 2018-10-04)
+ cargo --version
cargo 1.30.0 (a1a4ad372 2018-11-02)
+ rustc --version
rustc 1.30.1 (1433507eb 2018-11-07)
```